### PR TITLE
Add PDF-to-text poppler wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# generalscripts
+# General Scripts
+
+Collection of small utilities and examples. This repository now also contains
+`pdf_to_text`, a simple Python wrapper around the `poppler-utils` commands such
+as `pdftotext`.
+
+See `pdf_to_text/README.md` for details.

--- a/pdf_to_text/README.md
+++ b/pdf_to_text/README.md
@@ -1,0 +1,25 @@
+# PDF-to-text
+
+Simple Python wrapper around `poppler-utils` commands such as `pdftotext` and
+`pdftohtml`. The module exposes `run_poppler_util` which forwards options to the
+underlying command and returns its standard output without modification.
+
+## Requirements
+- `poppler-utils` must be installed on the host system.
+- Python 3.8+
+
+No external Python packages are required.
+
+## Usage
+
+```python
+from pdf_to_text import run_poppler_util
+
+# Example: get text from a PDF using pdftotext
+output = run_poppler_util('pdftotext', 'document.pdf', options=['-layout', '-'])
+print(output)
+```
+
+Additional options such as `-htmlmeta`, `-xml`, or others can be supplied via the
+`options` argument. Anything printed by the underlying command is returned
+verbatim.

--- a/pdf_to_text/__init__.py
+++ b/pdf_to_text/__init__.py
@@ -1,0 +1,3 @@
+from .wrapper import run_poppler_util
+
+__all__ = ["run_poppler_util"]

--- a/pdf_to_text/requirements.txt
+++ b/pdf_to_text/requirements.txt
@@ -1,0 +1,1 @@
+# No external Python packages required

--- a/pdf_to_text/wrapper.py
+++ b/pdf_to_text/wrapper.py
@@ -1,0 +1,32 @@
+import subprocess
+from typing import List, Optional
+
+
+def run_poppler_util(command: str, pdf_path: str, output_path: Optional[str] = None, options: Optional[List[str]] = None) -> str:
+    """Run a poppler utility command and return its stdout.
+
+    Parameters
+    ----------
+    command: str
+        Name of the poppler utility (e.g. ``pdftotext``, ``pdftohtml``).
+    pdf_path: str
+        Path to the PDF file to process.
+    output_path: Optional[str]
+        Optional path for the output file. If ``None`` the command's stdout is captured.
+    options: Optional[List[str]]
+        Additional command line options as a list.
+
+    Returns
+    -------
+    str
+        The stdout produced by the command.
+    """
+    if options is None:
+        options = []
+
+    cmd = [command] + options + [pdf_path]
+    if output_path:
+        cmd.append(output_path)
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return result.stdout


### PR DESCRIPTION
## Summary
- add a `pdf_to_text` module that exposes a thin wrapper around poppler-utils commands
- document usage and requirements
- update root README with module info

## Testing
- `python -m py_compile pdf_to_text/wrapper.py pdf_to_text/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684b562d50ec832a80b5a69a2155f502