### PR TITLE
Add lsx utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,32 @@ Collection of small utilities and examples. This repository now also contains
 as `pdftotext`.
 
 See `pdf_to_text/README.md` for details.
+
+## lsx
+
+`lsx` is a lightweight listing helper built on `find`.  It omits the
+permissions, owner and group columns so the output fits better on small
+screens.  When used with `-l` it prints only the file size and name.  Options
+`-t` and `-r` control sorting by modification time and reversal respectively
+and `-h` makes the reported size human readable.
+
+Example usage:
+
+```bash
+$ lsx -ltrh
+```
+
+### Installation
+
+Run the installer script with superuser permissions (installs to
+`/usr/local/bin` by default):
+
+```bash
+sudo ./install_lsx.sh
+```
+
+Specify a different directory by providing a path:
+
+```bash
+sudo ./install_lsx.sh /opt/bin
+```

--- a/install_lsx.sh
+++ b/install_lsx.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Install lsx script to /usr/local/bin or specified directory
+# lsx prints file size and name only and supports basic ls-like options.
+
+DEST=${1:-/usr/local/bin}
+
+if [ ! -d "$DEST" ]; then
+    echo "Creating directory $DEST"
+    mkdir -p "$DEST" || exit 1
+fi
+
+install -m 0755 "$(dirname "$0")/lsx" "$DEST/lsx" && echo "Installed lsx to $DEST/lsx"

--- a/lsx
+++ b/lsx
@@ -1,0 +1,58 @@
+#!/bin/bash
+# lsx - minimal ls for small screens using find
+#
+# Supports options similar to `ls`:
+#   -l  show file size and name only
+#   -t  sort by modification time
+#   -r  reverse sort order
+#   -h  human readable sizes when used with -l
+# Usage: lsx [-ltrh] [path ...]
+
+list=false
+human=false
+sort_by=name
+reverse=false
+
+while getopts "ltrh" opt; do
+    case "$opt" in
+        l) list=true ;;
+        t) sort_by=time ;;
+        r) reverse=true ;;
+        h) human=true ;;
+        *) echo "Usage: lsx [-ltrh] [path...]" >&2; exit 1 ;;
+    esac
+done
+shift $((OPTIND-1))
+
+paths=("$@")
+if [ ${#paths[@]} -eq 0 ]; then
+    paths=(.)
+fi
+
+for path in "${paths[@]}"; do
+    [ ${#paths[@]} -gt 1 ] && echo "$path:"
+    entries=$(find "$path" -maxdepth 1 -mindepth 1 -printf '%T@ %s %f\n')
+    if [ "$sort_by" = "time" ]; then
+        sort_cmd="sort -n"
+    else
+        sort_cmd="sort -k3"
+    fi
+    if [ "$reverse" = true ]; then
+        sort_cmd="$sort_cmd -r"
+    fi
+    entries=$(echo "$entries" | eval $sort_cmd)
+    while IFS= read -r line; do
+        size="$(echo "$line" | awk '{print $2}')"
+        name="$(echo "$line" | cut -d' ' -f3-)"
+        if [ "$list" = true ]; then
+            if [ "$human" = true ]; then
+                size=$(numfmt --to=iec -- "$size")
+            fi
+            printf '%s %s\n' "$size" "$name"
+        else
+            printf '%s\n' "$name"
+        fi
+    done <<< "$entries"
+    [ ${#paths[@]} -gt 1 ] && echo
+done
+


### PR DESCRIPTION
## Summary
- enhance `lsx` to use `find` and only print size and name
- update installer comments
- document new behaviour and usage example

## Testing
- `./lsx -l | head`
- `./lsx -ltrh`
- `sudo ./install_lsx.sh /tmp/bin`


------
https://chatgpt.com/codex/tasks/task_e_685493870864832ab32d79a6636ca0f5