### PR TITLE
Add specification-kit repository scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Collection of small utilities and examples. This repository now also contains
 `pdf_to_text`, a simple Python wrapper around the `poppler-utils` commands such
 as `pdftotext`.
 
+## specification-kit
+
+`specification-kit` is a scaffold for starting a documentation repository
+focused on technical specifications. It includes a README-driven overview along
+with placeholder directories for templates, examples, guides, and tooling so
+teams can jumpstart a consistent spec workflow. See
+[`specification-kit/README.md`](specification-kit/README.md) for details.
+
 See `pdf_to_text/README.md` for details.
 
 ## lsx

--- a/specification-kit/README.md
+++ b/specification-kit/README.md
@@ -1,0 +1,40 @@
+# Specification Kit
+
+Specification Kit is a lightweight repository scaffold for authoring, reviewing,
+and publishing technical specifications. It provides a consistent directory
+layout, reusable templates, and contribution guidelines that help teams write
+clear, auditable specifications with minimal setup.
+
+## Repository structure
+
+```
+specification-kit/
+├── README.md            # Overview and quick start guide
+├── docs/
+│   ├── templates/       # Templates for new specifications
+│   └── examples/        # Example specifications to reference
+├── guides/              # Writing guides and checklists
+└── tools/               # Automation helpers (linting, validation, etc.)
+```
+
+## Quick start
+
+1. Clone this repository and copy the `specification-kit` directory to the
+   location where you keep documentation.
+2. Update the `docs/templates` files to match your organization's vocabulary.
+3. Author new specifications in `docs/examples` or your preferred location using
+   the provided templates.
+4. Customize `guides` and `tools` to include your review processes, linters, or
+   CI hooks.
+
+## Contributing
+
+1. Create a new branch for your change.
+2. Update or add specification templates, guides, or tooling.
+3. Run any validation tools included under `tools/`.
+4. Submit a pull request describing the improvements to the kit.
+
+## License
+
+Choose a license that fits your project (e.g., MIT, Apache 2.0) and add it to
+this directory so downstream users know how they can use and modify the kit.

--- a/specification-kit/docs/examples/README.md
+++ b/specification-kit/docs/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+Use this directory to maintain high-quality specification examples that writers
+can reference when drafting new documents. Include specs that demonstrate best
+practices, such as clear acceptance criteria, traceable requirements, and
+concise decision rationale.
+
+Consider tagging example specs by domain (e.g., backend, frontend, process)
+using prefixes or subdirectories so readers can quickly find relevant material.

--- a/specification-kit/docs/templates/README.md
+++ b/specification-kit/docs/templates/README.md
@@ -1,0 +1,15 @@
+# Templates
+
+Store reusable specification templates in this directory. Templates should cover
+key sections such as overview, requirements, diagrams, and decision records so
+that authors can quickly start writing.
+
+## Recommended templates
+
+- `architecture.md` – for high-level system or service designs
+- `feature.md` – for product feature requirements and success metrics
+- `process.md` – for operational procedures and runbooks
+
+Each template should include front-matter metadata (title, authors, status,
+reviewers) and clearly marked placeholders that explain what information the
+writer needs to provide.

--- a/specification-kit/guides/README.md
+++ b/specification-kit/guides/README.md
@@ -1,0 +1,12 @@
+# Guides
+
+Author how-to guides, review checklists, and reference material for writers and
+reviewers in this directory. Helpful examples include:
+
+- Specification authoring checklist
+- Review rubric focusing on clarity, completeness, and testability
+- Glossary of terms used across your organization
+- Style guide for diagrams, tables, and numbering
+
+Organize guide documents using subfolders if the content grows beyond a handful
+of files.

--- a/specification-kit/tools/README.md
+++ b/specification-kit/tools/README.md
@@ -1,0 +1,12 @@
+# Tools
+
+Automate quality checks and publishing workflows by placing scripts or
+configuration files in this directory. Potential additions include:
+
+- Markdown or reStructuredText linters
+- Diagram generation scripts (e.g., PlantUML, Mermaid CLI wrappers)
+- Specification validation tools that enforce required sections or metadata
+- Continuous integration workflows for verifying spec quality
+
+Document how to run each tool and list any dependencies so contributors can set
+up the toolkit quickly.


### PR DESCRIPTION
## Summary
- add a `specification-kit` scaffold with directories for templates, examples, guides, and tooling
- document how to use the kit through README files in each directory
- reference the new kit from the root repository README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1f062b5c4832aaef4f01cf5d5a212